### PR TITLE
Add Initial Release of terraform-aws-dms Module for AWS Database Migration Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Local .terraform directories
+**/.terraform/*
+
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+
+# Ignore environment files containing secrets for local execution of terraform
+.env
+# Ignore .vscode folder and all the consisting files
+.vscode/
+
+# Ignore .idea folder and all the consisting files
+.idea/.terraform/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
-# terraform-aws-template
+# terraform-aws-dms
 
-[![Lint Status](https://github.com/tothenew/terraform-aws-template/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-template/actions)
-[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-template)](https://github.com/tothenew/terraform-aws-template/blob/master/LICENSE)
+[![Lint Status](https://github.com/tothenew/terraform-aws-dms/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-dms/actions)
+[![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-dms)](https://github.com/tothenew/terraform-aws-dms/blob/master/LICENSE)
 
-This is a template to use for baseline. The default actions will provide updates for section bitween Requirements and Outputs.
+This module provisions and configures Amazon MQ for dms, enabling secure and scalable message brokering within a region.
 
-The following content needed to be created and managed:
- - Introduction
-     - Explaination of module 
-     - Intended users
- - Resource created and managed by this module
- - Example Usages
+The following resources will be created:
+- Brokers
+- Configurations
+
+## Usages
+```
+module "dms {
+  source                        =   "./module/dms"
+  repl_subnet_group_subnet_ids  =   ["subnet-123456789","subnet-987654321"]
+  repl_instance_engine_version  =   "3.5.4"
+  source_endpoint               =   var.source_endpoint
+  destination_endpoint          =   var.destination_endpoint
+
+  replication_task  = {
+    replication_task_id       = "example-cdc"
+    migration_type            = "cdc"
+    replication_task_settings = "./task_settings.json"
+    table_mappings            = "./table_mappings.json"
+    source_endpoint_key       = "source"
+    target_endpoint_key       = "destination"
+  }
+
+  event_subscriptions           =   var.event_subscriptions
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -21,24 +40,32 @@ The following content needed to be created and managed:
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_active-mq"></a> [active\_mq](#module\_active\_mq) | ./module/active-mq | n/a |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
 
 ## Outputs
 
-No outputs.
-<!-- END_TF_DOCS -->
+| Name | Description |
+|------|-------------|
+
 
 ## Authors
 
@@ -46,4 +73,4 @@ Module managed by [TO THE NEW Pvt. Ltd.](https://github.com/tothenew)
 
 ## License
 
-Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-template/blob/main/LICENSE) for full details.
+Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-dms/blob/main/LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -3,22 +3,30 @@
 [![Lint Status](https://github.com/tothenew/terraform-aws-dms/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-dms/actions)
 [![LICENSE](https://img.shields.io/github/license/tothenew/terraform-aws-dms)](https://github.com/tothenew/terraform-aws-dms/blob/master/LICENSE)
 
-This module provisions and configures Amazon MQ for dms, enabling secure and scalable message brokering within a region.
+This module provisions and configures **AWS Database Migration Service (DMS)** resources for securely and reliably migrating databases in AWS.
 
 The following resources will be created:
-- Brokers
-- Configurations
 
-## Usages
-```
-module "dms {
-  source                        =   "./module/dms"
-  repl_subnet_group_subnet_ids  =   ["subnet-123456789","subnet-987654321"]
-  repl_instance_engine_version  =   "3.5.4"
-  source_endpoint               =   var.source_endpoint
-  destination_endpoint          =   var.destination_endpoint
+* DMS Replication Subnet Group
+* DMS Replication Instance
+* DMS Endpoints
 
-  replication_task  = {
+  * Source
+  * Target
+* DMS Replication Task
+* DMS Event Subscriptions
+
+## Usage
+
+```hcl
+module "dms" {
+  source                        = "./module/dms"
+  repl_subnet_group_subnet_ids = ["subnet-123456789", "subnet-987654321"]
+  repl_instance_engine_version = "3.5.4"
+  source_endpoint              = var.source_endpoint
+  destination_endpoint         = var.destination_endpoint
+
+  replication_task = {
     replication_task_id       = "example-cdc"
     migration_type            = "cdc"
     replication_task_settings = "./task_settings.json"
@@ -27,45 +35,60 @@ module "dms {
     target_endpoint_key       = "destination"
   }
 
-  event_subscriptions           =   var.event_subscriptions
+  event_subscriptions = var.event_subscriptions
 }
 ```
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| Name      | Version  |
+| --------- | -------- |
+| terraform | >= 1.3.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| ---- | ------- |
+| aws  | n/a     |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_active-mq"></a> [active\_mq](#module\_active\_mq) | ./module/active-mq | n/a |
+| Name       | Source             | Version |
+| ---------- | ------------------ | ------- |
+| active\_mq | ./module/active-mq | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-
+| Name                                      | Type     |
+| ----------------------------------------- | -------- |
+| aws\_dms\_replication\_subnet\_group.this | resource |
+| aws\_dms\_replication\_instance.this      | resource |
+| aws\_dms\_endpoint.source                 | resource |
+| aws\_dms\_endpoint.target                 | resource |
+| aws\_dms\_replication\_task.this          | resource |
+| aws\_dms\_event\_subscription.this        | resource |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| Name                             | Description                                 | Type         | Default | Required |
+| -------------------------------- | ------------------------------------------- | ------------ | ------- | :------: |
+| repl\_subnet\_group\_subnet\_ids | Subnet IDs for the replication subnet group | list(string) | n/a     |    yes   |
+| repl\_instance\_engine\_version  | Engine version of the replication instance  | string       | n/a     |    yes   |
+| source\_endpoint                 | Configuration for source endpoint           | any          | n/a     |    yes   |
+| destination\_endpoint            | Configuration for destination endpoint      | any          | n/a     |    yes   |
+| replication\_task                | Details of the replication task             | map(any)     | n/a     |    yes   |
+| event\_subscriptions             | List of DMS event subscriptions             | any          | `[]`    |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-
+| Name                       | Description                         |
+| -------------------------- | ----------------------------------- |
+| replication\_instance\_arn | ARN of the DMS replication instance |
+| source\_endpoint\_arn      | ARN of the DMS source endpoint      |
+| target\_endpoint\_arn      | ARN of the DMS target endpoint      |
+| replication\_task\_arn     | ARN of the DMS replication task     |
 
 ## Authors
 

--- a/_data.tf
+++ b/_data.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "dms_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["dms.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "dms_cloudwatch_logs" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents"
+    ]
+    resources = ["*"]
+  }
+}

--- a/_locals.tf
+++ b/_locals.tf
@@ -1,0 +1,9 @@
+locals {
+  replication_task_settings = jsondecode(file(var.replication_task.replication_task_settings))
+  table_mappings            = jsondecode(file(var.replication_task.table_mappings))
+
+  service_name_prefix = var.name == "" ? terraform.workspace : var.name
+  project_name_prefix = var.name == "" ? terraform.workspace : var.name
+  account_name_prefix = var.name == "" ? terraform.workspace : var.name
+  common_tags         = length(var.common_tags) == 0 ? var.default_tags : merge(var.default_tags, var.common_tags)
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -1,0 +1,241 @@
+variable "name" {
+  type        = string
+  description = "A string value to describe prefix of all the resources"
+  default     = "non-prod-generic"
+}
+
+variable "common_tags" {
+  type        = map(string)
+  description = "A map to add common tags to all the resources"
+  default = {
+    "Project"     = "Internal"
+    "Environment" = "Dev"
+    "ManagedBy"   = "Terraform"
+  }
+}
+
+variable "default_tags" {
+  type        = map(string)
+  description = "A map to add common tags to all the resources"
+  default = {
+    "Scope" : "DMS"
+    "CreatedBy" : "Terraform"
+  }
+}
+
+# VPC and Networking
+variable "vpc_id" {
+  description = "The VPC ID where DMS will be deployed"
+  type        = string
+  default     = "vpc-0312fdce447d35d09"
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for DMS"
+  type        = list(string)
+  default     = ["subnet-0f00ff9c7b685dcca", "subnet-082060390bd084408"]
+}
+
+variable "from_port" {
+  description = "security groups from port"
+  type        = number
+  default     = 61616
+}
+
+variable "to_port" {
+  description = "security groups to port"
+  type        = number
+  default     = 61616
+}
+
+variable "cidr_blocks" {
+  type        = list(string)
+  description = "A list of CIDR block ID's to allow access"
+  default     = ["10.0.0.0/16"]
+}
+
+# DMS Subnet Group
+variable "repl_subnet_group_name" {
+  description = "The name for the replication subnet group"
+  type        = string
+  default     = "dms-subnet"
+}
+
+variable "repl_subnet_group_description" {
+  description = "The description for the replication subnet group"
+  type        = string
+  default     = "DMS Subnet group"
+}
+
+# DMS Instance
+variable "repl_instance_allocated_storage" {
+  description = "The allocated storage in gigabytes"
+  type        = number
+  default     = 64
+}
+
+variable "repl_instance_auto_minor_version_upgrade" {
+  description = "Whether minor engine upgrades will be applied automatically"
+  type        = bool
+  default     = true
+}
+
+variable "repl_instance_allow_major_version_upgrade" {
+  description = "Whether major version upgrades are allowed"
+  type        = bool
+  default     = true
+}
+
+variable "repl_instance_apply_immediately" {
+  description = "Whether to apply changes immediately"
+  type        = bool
+  default     = true
+}
+
+variable "repl_instance_engine_version" {
+  description = "The engine version number"
+  type        = string
+  default     = "3.5.4"
+}
+
+variable "repl_instance_multi_az" {
+  description = "Whether the instance should be multi-AZ"
+  type        = bool
+  default     = true
+}
+
+variable "repl_instance_preferred_maintenance_window" {
+  description = "The weekly time range during which maintenance is performed"
+  type        = string
+  default     = "sun:10:30-sun:14:30"
+}
+
+variable "repl_instance_publicly_accessible" {
+  description = "Whether the instance is publicly accessible"
+  type        = bool
+  default     = false
+}
+
+variable "repl_instance_class" {
+  description = "The compute and memory capacity of the instance"
+  type        = string
+  default     = "dms.t3.medium"
+}
+
+variable "repl_instance_id" {
+  description = "The identifier for the replication instance"
+  type        = string
+  default     = "test-instance-id"
+}
+
+# Endpoints
+variable "source_endpoint" {
+  description = "Configuration for the source endpoint"
+  type = object({
+    database_name = string
+    endpoint_id   = string
+    endpoint_type = string
+    engine_name   = string
+    username      = string
+    password      = string
+    port          = number
+    server_name   = string
+    ssl_mode      = string
+    tags          = map(string)
+  })
+  default = {
+    database_name = "testdb"
+    endpoint_id   = "example-source"
+    endpoint_type = "source"
+    engine_name   = "aurora-postgresql"
+    username      = "postgresqlUser"
+    password      = "youShouldPickABetterPassword123!"
+    port          = 5432
+    server_name   = "dms-ex-src.cluster-abcdefghijk.us-east-1.rds.amazonaws.com"
+    ssl_mode      = "none"
+    tags          = { EndpointType = "source" }
+  }
+}
+
+variable "destination_endpoint" {
+  description = "Configuration for the destination endpoint"
+  type = object({
+    database_name = string
+    endpoint_id   = string
+    endpoint_type = string
+    engine_name   = string
+    username      = string
+    password      = string
+    port          = number
+    server_name   = string
+    ssl_mode      = string
+    tags          = map(string)
+  })
+  default = {
+    database_name = "testdb"
+    endpoint_id   = "example-destination"
+    endpoint_type = "target"
+    engine_name   = "aurora"
+    username      = "mysqlUser"
+    password      = "passwordsDoNotNeedToMatch789?"
+    port          = 3306
+    server_name   = "dms-ex-dest.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com"
+    ssl_mode      = "none"
+    tags          = { EndpointType = "destination" }
+  }
+}
+
+# Replication Task
+variable "replication_task" {
+  description = "Configuration for the replication task"
+  type = object({
+    replication_task_id       = string
+    migration_type            = string
+    replication_task_settings = string
+    table_mappings            = string
+    source_endpoint_key       = string
+    target_endpoint_key       = string
+    tags                      = map(string)
+  })
+  default = {
+    replication_task_id       = "example-cdc"
+    migration_type            = "cdc"
+    replication_task_settings = "./task_settings.json"
+    table_mappings            = "./table_mappings.json"
+    source_endpoint_key       = "source"
+    target_endpoint_key       = "destination"
+    tags                      = { Task = "PostgreSQL-to-MySQL" }
+  }
+}
+
+# Event Subscriptions
+variable "event_subscriptions" {
+  description = "Configuration for event subscriptions"
+  type = map(object({
+    name                             = string
+    enabled                          = bool
+    source_type                      = string
+    sns_topic_arn                    = string
+    event_categories                 = list(string)
+    instance_event_subscription_keys = optional(list(string))
+    task_event_subscription_keys     = optional(list(string))
+  }))
+  default = {
+    instance = {
+      name                             = "instance-events"
+      enabled                          = true
+      instance_event_subscription_keys = ["example"]
+      source_type                      = "replication-instance"
+      sns_topic_arn                    = "arn:aws:sns:us-east-1:001861987316:dms-test-sns"
+      event_categories                 = ["failure", "creation", "deletion", "maintenance", "failover", "low storage", "configuration change"]
+    },
+    task = {
+      name                         = "task-events"
+      enabled                      = true
+      task_event_subscription_keys = ["cdc_ex"]
+      source_type                  = "replication-task"
+      sns_topic_arn                = "arn:aws:sns:us-east-1:001861987316:dms-test-sns"
+      event_categories             = ["failure", "state change", "creation", "deletion", "configuration change"]
+    }
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_role" "dms_vpc_role" {
+  name               = "dms-vpc-role"
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "dms_vpc_role_attachment" {
+  role       = aws_iam_role.dms_vpc_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+}
+
+resource "aws_iam_role_policy" "dms_cloudwatch_logs" {
+  name   = "dms-cloudwatch-logs-policy"
+  role   = aws_iam_role.dms_vpc_role.id
+  policy = data.aws_iam_policy_document.dms_cloudwatch_logs.json
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+module "dms" {
+  source = "./module/dms"
+
+  # Subnet Group
+  repl_subnet_group_name        = var.repl_subnet_group_name
+  repl_subnet_group_description = var.repl_subnet_group_description
+  repl_subnet_group_subnet_ids  = var.private_subnet_ids
+
+  # Replication Instance
+  repl_instance_allocated_storage            = var.repl_instance_allocated_storage
+  repl_instance_auto_minor_version_upgrade   = var.repl_instance_auto_minor_version_upgrade
+  repl_instance_allow_major_version_upgrade  = var.repl_instance_allow_major_version_upgrade
+  repl_instance_apply_immediately            = var.repl_instance_apply_immediately
+  repl_instance_engine_version               = var.repl_instance_engine_version
+  repl_instance_multi_az                     = var.repl_instance_multi_az
+  repl_instance_preferred_maintenance_window = var.repl_instance_preferred_maintenance_window
+  repl_instance_publicly_accessible          = var.repl_instance_publicly_accessible
+  repl_instance_class                        = var.repl_instance_class
+  repl_instance_id                           = var.repl_instance_id
+  repl_instance_vpc_security_group_ids       = [aws_security_group.dms_sg.id]
+
+  # Endpoints
+  source_endpoint      = var.source_endpoint
+  destination_endpoint = var.destination_endpoint
+
+  # Replication Task (with JSON files)
+  replication_task = {
+    replication_task_id       = var.replication_task.replication_task_id
+    migration_type            = var.replication_task.migration_type
+    replication_task_settings = var.replication_task.replication_task_settings
+    table_mappings            = var.replication_task.table_mappings
+    source_endpoint_key       = var.replication_task.source_endpoint_key
+    target_endpoint_key       = var.replication_task.target_endpoint_key
+    tags                      = var.replication_task.tags
+  }
+
+  # Event Subscriptions
+  event_subscriptions = var.event_subscriptions
+
+  # Tags
+  tags = merge(var.common_tags, { Name = "${local.service_name_prefix}-dms" })
+}

--- a/module/dms/main.tf
+++ b/module/dms/main.tf
@@ -1,0 +1,78 @@
+resource "aws_dms_replication_subnet_group" "this" {
+  replication_subnet_group_id       = var.repl_subnet_group_name
+  replication_subnet_group_description = var.repl_subnet_group_description
+  subnet_ids                       = var.repl_subnet_group_subnet_ids
+  tags                             = var.tags
+}
+
+resource "aws_dms_replication_instance" "this" {
+  replication_instance_id           = var.repl_instance_id
+  replication_instance_class        = var.repl_instance_class
+  allocated_storage                 = var.repl_instance_allocated_storage
+  vpc_security_group_ids            = var.repl_instance_vpc_security_group_ids
+  replication_subnet_group_id       = aws_dms_replication_subnet_group.this.replication_subnet_group_id
+  engine_version                    = var.repl_instance_engine_version
+  publicly_accessible               = var.repl_instance_publicly_accessible
+  multi_az                          = var.repl_instance_multi_az
+  apply_immediately                 = var.repl_instance_apply_immediately
+  auto_minor_version_upgrade        = var.repl_instance_auto_minor_version_upgrade
+  allow_major_version_upgrade       = var.repl_instance_allow_major_version_upgrade
+  preferred_maintenance_window      = var.repl_instance_preferred_maintenance_window
+  tags                              = var.tags
+}
+
+resource "aws_dms_endpoint" "source" {
+  endpoint_id                   = var.source_endpoint.endpoint_id
+  endpoint_type                 = "source"
+  engine_name                   = var.source_endpoint.engine_name
+  username                      = var.source_endpoint.username
+  password                      = var.source_endpoint.password
+  server_name                   = var.source_endpoint.server_name
+  port                          = var.source_endpoint.port
+  database_name                 = var.source_endpoint.database_name
+  ssl_mode                      = var.source_endpoint.ssl_mode
+  extra_connection_attributes   = var.source_endpoint.extra_connection_attributes
+  tags                          = var.source_endpoint.tags
+}
+
+resource "aws_dms_endpoint" "destination" {
+  endpoint_id                   = var.destination_endpoint.endpoint_id
+  endpoint_type                 = "target"
+  engine_name                   = var.destination_endpoint.engine_name
+  username                      = var.destination_endpoint.username
+  password                      = var.destination_endpoint.password
+  server_name                   = var.destination_endpoint.server_name
+  port                          = var.destination_endpoint.port
+  database_name                 = var.destination_endpoint.database_name
+  ssl_mode                      = var.destination_endpoint.ssl_mode
+  tags                          = var.destination_endpoint.tags
+}
+
+resource "aws_dms_replication_task" "this" {
+  replication_task_id           = var.replication_task.replication_task_id
+  migration_type                = var.replication_task.migration_type
+  replication_instance_arn      = aws_dms_replication_instance.this.replication_instance_arn
+  source_endpoint_arn           = aws_dms_endpoint.source.endpoint_arn
+  target_endpoint_arn           = aws_dms_endpoint.destination.endpoint_arn
+  replication_task_settings     = file(var.replication_task.replication_task_settings)
+  table_mappings                = file(var.replication_task.table_mappings)
+  tags                          = var.replication_task.tags
+}
+
+resource "aws_dms_event_subscription" "instance_events" {
+  name             = var.event_subscriptions.instance.name
+  sns_topic_arn    = var.event_subscriptions.instance.sns_topic_arn
+  source_type      = var.event_subscriptions.instance.source_type
+  source_ids       = [aws_dms_replication_instance.this.replication_instance_id]
+  event_categories = var.event_subscriptions.instance.event_categories
+  enabled          = var.event_subscriptions.instance.enabled
+}
+
+resource "aws_dms_event_subscription" "task_events" {
+  name             = var.event_subscriptions.task.name
+  sns_topic_arn    = var.event_subscriptions.task.sns_topic_arn
+  source_type      = var.event_subscriptions.task.source_type
+  source_ids       = [aws_dms_replication_task.this.replication_task_id]
+  event_categories = var.event_subscriptions.task.event_categories
+  enabled          = var.event_subscriptions.task.enabled
+}

--- a/module/dms/output.tf
+++ b/module/dms/output.tf
@@ -1,0 +1,15 @@
+output "replication_instance_arn" {
+  value = aws_dms_replication_instance.this.replication_instance_arn
+}
+
+output "replication_task_id" {
+  value = aws_dms_replication_task.this.replication_task_id
+}
+
+output "source_endpoint_arn" {
+  value = aws_dms_endpoint.source.endpoint_arn
+}
+
+output "destination_endpoint_arn" {
+  value = aws_dms_endpoint.destination.endpoint_arn
+}

--- a/module/dms/variable.tf
+++ b/module/dms/variable.tf
@@ -1,0 +1,81 @@
+variable "repl_subnet_group_name" {}
+variable "repl_subnet_group_description" {}
+variable "repl_subnet_group_subnet_ids" {
+  type = list(string)
+}
+
+variable "repl_instance_id" {}
+variable "repl_instance_class" {}
+variable "repl_instance_allocated_storage" {}
+variable "repl_instance_engine_version" {}
+variable "repl_instance_vpc_security_group_ids" {
+  type = list(string)
+}
+variable "repl_instance_publicly_accessible" {}
+variable "repl_instance_multi_az" {}
+variable "repl_instance_apply_immediately" {}
+variable "repl_instance_auto_minor_version_upgrade" {}
+variable "repl_instance_allow_major_version_upgrade" {}
+variable "repl_instance_preferred_maintenance_window" {}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "source_endpoint" {
+  type = object({
+    endpoint_id                 = string
+    engine_name                 = string
+    username                    = string
+    password                    = string
+    server_name                 = string
+    port                        = number
+    database_name               = string
+    ssl_mode                    = string
+    extra_connection_attributes = optional(string)
+    tags                        = map(string)
+  })
+}
+
+variable "destination_endpoint" {
+  type = object({
+    endpoint_id     = string
+    engine_name     = string
+    username        = string
+    password        = string
+    server_name     = string
+    port            = number
+    database_name   = string
+    ssl_mode        = string
+    tags            = map(string)
+  })
+}
+
+variable "replication_task" {
+  type = object({
+    replication_task_id       = string
+    migration_type            = string
+    replication_task_settings = string
+    table_mappings            = string
+    tags                      = map(string)
+  })
+}
+
+variable "event_subscriptions" {
+  type = object({
+    instance = object({
+      name               = string
+      enabled            = bool
+      sns_topic_arn      = string
+      source_type        = string
+      event_categories   = list(string)
+    })
+    task = object({
+      name               = string
+      enabled            = bool
+      sns_topic_arn      = string
+      source_type        = string
+      event_categories   = list(string)
+    })
+  })
+}

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "dms_sg" {
+  name        = "${local.service_name_prefix}-dms-sg"
+  description = "dms security group"
+  vpc_id      = var.vpc_id
+  tags = merge(local.common_tags, tomap({
+    "Name" : local.project_name_prefix
+    })
+  )
+
+  ingress {
+    from_port   = var.from_port
+    to_port     = var.to_port
+    protocol    = "tcp"
+    cidr_blocks = var.cidr_blocks
+  }
+}

--- a/table_mappings.json
+++ b/table_mappings.json
@@ -1,0 +1,14 @@
+{
+    "rules": [
+      {
+        "rule-type": "selection",
+        "rule-id": "1",
+        "rule-name": "1",
+        "object-locator": {
+          "schema-name": "%",
+          "table-name": "%"
+        },
+        "rule-action": "include"
+      }
+    ]
+  }

--- a/task_settings.json
+++ b/task_settings.json
@@ -1,0 +1,86 @@
+{
+    "TargetMetadata": {
+      "TargetSchema": "",
+      "SupportLobs": true,
+      "FullLobMode": false,
+      "LobChunkSize": 64,
+      "LimitedSizeLobMode": true,
+      "LobMaxSize": 32,
+      "InlineLobMaxSize": 0,
+      "LoadMaxFileSize": 0,
+      "ParallelLoadThreads": 0,
+      "ParallelLoadBufferSize": 0,
+      "BatchApplyEnabled": false,
+      "TaskRecoveryTableEnabled": false
+    },
+    "FullLoadSettings": {
+      "TargetTablePrepMode": "DROP_AND_CREATE",
+      "CreatePkAfterFullLoad": false,
+      "StopTaskCachedChangesApplied": false,
+      "StopTaskCachedChangesNotApplied": false,
+      "MaxFullLoadSubTasks": 8,
+      "TransactionConsistencyTimeout": 600,
+      "CommitRate": 10000
+    },
+    "Logging": {
+      "EnableLogging": true,
+      "LogComponents": [
+        {
+          "Id": "TRANSFORMATION",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "SOURCE_UNLOAD",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "IO",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "TARGET_LOAD",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "PERFORMANCE",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "SOURCE_CAPTURE",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "SORTER",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "REST_SERVER",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "TARGET_APPLY",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "TASK_MANAGER",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "TABLES_MANAGER",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "METADATA_MANAGER",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "FILE_FACTORY",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        },
+        {
+          "Id": "COMMON",
+          "Severity": "LOGGER_SEVERITY_DEFAULT"
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
This pull request introduces the initial release of the terraform-aws-dms module, designed to simplify and standardize the provisioning of AWS Database Migration Service (DMS) resources using Terraform.
Key Features:

    DMS Replication Subnet Group: Define subnets for DMS replication infrastructure.

    DMS Replication Instance: Provision highly available and scalable replication instances.

    DMS Source & Target Endpoints: Support configuration for various supported database types.

    DMS Replication Task: Define migration or CDC tasks with custom task settings and table mappings.

    Event Subscriptions (Optional): Enable DMS event notifications via SNS.

Module Highlights:

    Input variables for full customization of all DMS components.

    Supports CDC, full load, and hybrid migration types.

    Easy integration with existing networking and IAM setups.

    Structured output values for easy reference in downstream modules.

Documentation:

    Includes a detailed README.md with usage examples.

    Outputs and input variables fully documented.

    Compatible with Terraform >= 1.3.0.